### PR TITLE
Support for Logrus Formatters

### DIFF
--- a/logrus/formatter.go
+++ b/logrus/formatter.go
@@ -1,0 +1,40 @@
+package logrus
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+const DefaultTimestampFormat = time.RFC3339
+
+// This is to not silently overwrite `time`, `msg` and `level` fields when
+// dumping it. If this code wasn't there doing:
+//
+//  logrus.WithField("level", 1).Info("hello")
+//
+// Would just silently drop the user provided level. Instead with this code
+// it'll logged as:
+//
+//  {"level": "info", "fields.level": 1, "msg": "hello", "time": "..."}
+//
+// It's not exported because it's still using Data in an opinionated way. It's to
+// avoid code duplication between the two default formatters.
+//
+// More information at https://github.com/akutz/logrus/blob/master/formatter.go
+func prefixFieldClashes(data log.Fields) {
+	_, ok := data["time"]
+	if ok {
+		data["fields.time"] = data["time"]
+	}
+
+	_, ok = data["msg"]
+	if ok {
+		data["fields.msg"] = data["msg"]
+	}
+
+	_, ok = data["level"]
+	if ok {
+		data["fields.level"] = data["level"]
+	}
+}

--- a/logrus/json_formatter.go
+++ b/logrus/json_formatter.go
@@ -1,0 +1,48 @@
+package logrus
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/akutz/golf"
+)
+
+type JSONFormatter struct {
+	log.JSONFormatter
+}
+
+func (f *JSONFormatter) Format(entry *log.Entry) ([]byte, error) {
+	data := make(log.Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case golf.Golfs:
+			for ck, cv := range golf.Fore(k, v) {
+				data[ck] = cv
+			}
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+	prefixFieldClashes(data)
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = DefaultTimestampFormat
+	}
+
+	data["time"] = entry.Time.Format(timestampFormat)
+	data["msg"] = entry.Message
+	data["level"] = entry.Level.String()
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/logrus/json_formatter_test.go
+++ b/logrus/json_formatter_test.go
@@ -1,0 +1,100 @@
+package logrus
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func newJsonFormatter() *JSONFormatter {
+	return &JSONFormatter{log.JSONFormatter{}}
+}
+
+func TestLogrusWithJsonFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	log.SetFormatter(newJsonFormatter())
+
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Message = "the dark knight"
+	entry.Data = log.Fields{"hero": p}
+	s, _ := entry.String()
+
+	if !strings.Contains(s, `"hero.name":"Bruce"`) {
+		t.Fatalf(`missing "hero.name":"Bruce"`)
+	}
+
+	if !strings.Contains(s, `"hero.alias":"Batman"`) {
+		t.Fatalf(`missing "hero.alias":"Batman"`)
+	}
+
+	if !strings.Contains(s, `"hero.hideout.name":"JLU Tower"`) {
+		t.Fatalf(`missing "hero.hideout.name":"JLU Tower"`)
+	}
+
+	if !strings.Contains(s, `"hero.hideout.dimensionId":52`) {
+		t.Fatalf(`missing "hero.hideout.dimensionId":52`)
+	}
+}
+
+func TestGolfsWithJsonFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	jf := newJsonFormatter()
+	b, err := jf.Format(&log.Entry{
+		Message: "the dark knight", Data: log.Fields{"hero": p}})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.name":"Bruce"`)) < 0 {
+		t.Fatalf(`missing "hero.name":"Bruce"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.alias":"Batman"`)) < 0 {
+		t.Fatalf(`missing "hero.alias":"Batman"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.hideout.name":"JLU Tower"`)) < 0 {
+		t.Fatalf(`missing "hero.hideout.name":"JLU Tower"`)
+	}
+
+	if bytes.Index(b, ([]byte)(`"hero.hideout.dimensionId":52`)) < 0 {
+		t.Fatalf(`missing "hero.hideout.dimensionId":52`)
+	}
+}
+
+func TestGolfsWithJsonFormatterAndNonGolfer(t *testing.T) {
+	h := &Hideout{
+		Name:        "JLU Tower",
+		DimensionId: 52,
+	}
+
+	jf := newJsonFormatter()
+	b, err := jf.Format(&log.Entry{
+		Message: "secret base", Data: log.Fields{"hideout": h}})
+	if err != nil {
+		t.Fatal("Unable to format entry: ", err)
+	}
+	t.Log(string(b))
+
+	if bytes.Index(b, ([]byte)(`"hideout":{"Name":"JLU Tower","DimensionId":52}`)) < 0 {
+		t.Fatalf(`missing "hideout":{"Name":"JLU Tower","DimensionId":52}`)
+	}
+}

--- a/logrus/logrus_test.go
+++ b/logrus/logrus_test.go
@@ -1,0 +1,16 @@
+package logrus
+
+type Person struct {
+	Name    string   `golf:"name"`
+	Alias   string   `golf:"alias"`
+	Hideout *Hideout `golf:"hideout"`
+}
+
+func (p *Person) PlayGolf() bool {
+	return true
+}
+
+type Hideout struct {
+	Name        string `golf:"name"`
+	DimensionId int    `golf:"dimensionId"`
+}

--- a/logrus/text_formatter.go
+++ b/logrus/text_formatter.go
@@ -1,0 +1,204 @@
+package logrus
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/akutz/golf"
+)
+
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 34
+	gray    = 37
+)
+
+var (
+	baseTimestamp time.Time
+	isTerminal    bool
+)
+
+func init() {
+	baseTimestamp = time.Now()
+	isTerminal = log.IsTerminal()
+}
+
+func miniTS() int {
+	return int(time.Since(baseTimestamp) / time.Second)
+}
+
+// TextFormatter generates golf-enabled logs in plain-text formt.
+//
+// The Formatter interface is used to implement a custom Formatter. It takes an
+// `Entry`. It exposes all the fields, including the default ones:
+//
+// * `entry.Data["msg"]`. The message passed from Info, Warn, Error ..
+// * `entry.Data["time"]`. The timestamp.
+// * `entry.Data["level"]. The level the entry was logged at.
+//
+// Any additional fields added with `WithField` or `WithFields` are also in
+// `entry.Data`. Format is expected to return an array of bytes which are then
+// logged to `logger.Out`.
+//
+// More information at https://github.com/akutz/logrus/blob/master/formatter.go
+type TextFormatter struct {
+	log.TextFormatter
+}
+
+func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var keys []string = make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+
+	if !f.DisableSorting {
+		sort.Strings(keys)
+	}
+
+	b := &bytes.Buffer{}
+
+	prefixFieldClashes(entry.Data)
+
+	isColorTerminal := isTerminal && (runtime.GOOS != "windows")
+	isColored := (f.ForceColors || isColorTerminal) && !f.DisableColors
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = DefaultTimestampFormat
+	}
+	if isColored {
+		f.printColored(b, entry, keys, timestampFormat)
+	} else {
+		if !f.DisableTimestamp {
+			f.appendKeyValue(b, "time", entry.Time.Format(timestampFormat))
+		}
+		f.appendKeyValue(b, "level", entry.Level.String())
+		if entry.Message != "" {
+			f.appendKeyValue(b, "msg", entry.Message)
+		}
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func (f *TextFormatter) printColored(
+	b *bytes.Buffer,
+	entry *log.Entry,
+	keys []string,
+	timestampFormat string) {
+
+	var levelColor int
+	switch entry.Level {
+	case log.DebugLevel:
+		levelColor = gray
+	case log.WarnLevel:
+		levelColor = yellow
+	case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+		levelColor = red
+	default:
+		levelColor = blue
+	}
+
+	levelText := strings.ToUpper(entry.Level.String())[0:4]
+
+	if !f.FullTimestamp {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %-44s ",
+			levelColor, levelText, miniTS(), entry.Message)
+	} else {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %-44s ",
+			levelColor,
+			levelText,
+			entry.Time.Format(timestampFormat),
+			entry.Message)
+	}
+	for _, k := range keys {
+		v := entry.Data[k]
+
+		switch v.(type) {
+		case golf.Golfs:
+			fields := golf.Fore(k, v)
+			for kk, vv := range fields {
+				switch vvt := vv.(type) {
+				case string:
+					if needsQuoting(vvt) {
+						fmt.Fprintf(b,
+							" \x1b[%dm%s\x1b[0m=%s",
+							levelColor, kk, vvt)
+					} else {
+						fmt.Fprintf(b,
+							" \x1b[%dm%s\x1b[0m=%q",
+							levelColor, kk, vvt)
+					}
+				default:
+					fmt.Fprintf(b,
+						" \x1b[%dm%s\x1b[0m=%+v",
+						levelColor, kk, vvt)
+				}
+
+			}
+		default:
+			fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%+v", levelColor, k, v)
+		}
+	}
+}
+
+func needsQuoting(text string) bool {
+	for _, ch := range text {
+		if !((ch >= 'a' && ch <= 'z') ||
+			(ch >= 'A' && ch <= 'Z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *TextFormatter) appendKeyValue(
+	b *bytes.Buffer,
+	key string, value interface{}) {
+
+	switch value.(type) {
+	case golf.Golfs:
+		for ck, cv := range golf.Fore(key, value) {
+			f.appendKeyValue(b, ck, cv)
+		}
+		return
+	}
+
+	b.WriteString(key)
+	b.WriteByte('=')
+
+	switch value := value.(type) {
+	case string:
+		if needsQuoting(value) {
+			b.WriteString(value)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	case error:
+		errmsg := value.Error()
+		if needsQuoting(errmsg) {
+			b.WriteString(errmsg)
+		} else {
+			fmt.Fprintf(b, "%q", value)
+		}
+	default:
+		fmt.Fprint(b, value)
+	}
+
+	b.WriteByte(' ')
+}

--- a/logrus/text_formatter_test.go
+++ b/logrus/text_formatter_test.go
@@ -1,0 +1,94 @@
+package logrus
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func newTextFormatter() *TextFormatter {
+	return &TextFormatter{log.TextFormatter{DisableColors: true}}
+}
+
+func TestLogrusWithTextFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	log.SetFormatter(newTextFormatter())
+
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Message = "the dark knight"
+	entry.Data = log.Fields{"hero": p}
+	s, _ := entry.String()
+
+	if !strings.Contains(s, "hero.name=Bruce") {
+		t.Fatalf("missing hero.name=Bruce")
+	}
+
+	if !strings.Contains(s, "hero.alias=Batman") {
+		t.Fatalf("missing hero.alias=Batman")
+	}
+
+	if !strings.Contains(s, `hero.hideout.name="JLU Tower"`) {
+		t.Fatalf(`missing hero.hideout.name="JLU Tower"`)
+	}
+
+	if !strings.Contains(s, "hero.hideout.dimensionId=52") {
+		t.Fatalf("missing hero.hideout.dimensionId=52")
+	}
+}
+
+func TestGolfsWithTextFormatter(t *testing.T) {
+	p := &Person{
+		Name:  "Bruce",
+		Alias: "Batman",
+		Hideout: &Hideout{
+			Name:        "JLU Tower",
+			DimensionId: 52,
+		},
+	}
+
+	tf := newTextFormatter()
+	b, _ := tf.Format(&log.Entry{
+		Message: "the dark knight", Data: log.Fields{"hero": p}})
+
+	if bytes.Index(b, ([]byte)("hero.name=Bruce")) < 0 {
+		t.Fatalf("missing hero.name=Bruce")
+	}
+
+	if bytes.Index(b, ([]byte)("hero.alias=Batman")) < 0 {
+		t.Fatalf("missing hero.alias=Batman")
+	}
+
+	if bytes.Index(b, ([]byte)(`hero.hideout.name="JLU Tower"`)) < 0 {
+		t.Fatalf(`missing hero.hideout.name="JLU Tower"`)
+	}
+
+	if bytes.Index(b, ([]byte)("hero.hideout.dimensionId=52")) < 0 {
+		t.Fatalf("missing hero.hideout.dimensionId=52")
+	}
+}
+
+func TestGolfsWithTextFormatterAndNonGolfer(t *testing.T) {
+	h := &Hideout{
+		Name:        "JLU Tower",
+		DimensionId: 52,
+	}
+
+	tf := newTextFormatter()
+	b, _ := tf.Format(&log.Entry{
+		Message: "secret base", Data: log.Fields{"hideout": h}})
+	t.Log(string(b))
+
+	if bytes.Index(b, ([]byte)("hideout=&{JLU Tower 52}")) < 0 {
+		t.Fatalf("missing hideout={JLU Tower 52}")
+	}
+}


### PR DESCRIPTION
This patch adds support for custom Logrus text and JSON formatters that are Golf-aware. This is a third-party, external integration approach to the pull-request at https://github.com/Sirupsen/logrus/pull/249.