### PR TITLE
Fix fore of non-ptr struct values

### DIFF
--- a/golf.go
+++ b/golf.go
@@ -167,7 +167,11 @@ func fore(key string, val interface{}, bk9 map[string]interface{}) {
 		ef = map[string]interface{}{}
 
 		// get the value's type
-		vt := reflect.ValueOf(val).Elem()
+		vt := reflect.ValueOf(val)
+
+		if vt.Kind() == reflect.Ptr {
+			vt = vt.Elem()
+		}
 
 		// get the value's type's type
 		tt := vt.Type()

--- a/golf_value_types_test.go
+++ b/golf_value_types_test.go
@@ -32,8 +32,32 @@ func TestNil(t *testing.T) {
 	}
 }
 
+func TestStructPointer(t *testing.T) {
+	f := Fore("test", &StructWithPointer{Foo: &FooStruct{Bar: "value"}})
+	assertMapLen(t, f, 1)
+	assertKeyEquals(t, f, "test.foo.Bar", "value")
+}
+
+func TestStructNonPointer(t *testing.T) {
+	f := Fore("test", &StructWithoutPointer{Foo: FooStruct{Bar: "value"}})
+	assertMapLen(t, f, 1)
+	assertKeyEquals(t, f, "test.foo.Bar", "value")
+}
+
 type StringThatGolfs string
 
 func (s *StringThatGolfs) GolfExportedFields() map[string]interface{} {
 	return map[string]interface{}{"golfer": fmt.Sprintf("%s %s", *s, *s)}
+}
+
+type FooStruct struct {
+	Bar string
+}
+
+type StructWithPointer struct {
+	Foo *FooStruct `golf:"foo"`
+}
+
+type StructWithoutPointer struct {
+	Foo FooStruct `golf:"foo"`
 }


### PR DESCRIPTION
Fixes #2

Adds test that fails on git master:

```
--- FAIL: TestStructNonPointer (0.00s)
panic: reflect: call of reflect.Value.Elem on struct Value [recovered]
	panic: reflect: call of reflect.Value.Elem on struct Value

goroutine 23 [running]:
panic(0x551f20, 0xc8200ae1c0)
	/usr/lib/go-1.6/src/runtime/panic.go:481 +0x3e6
testing.tRunner.func1(0xc8200ba360)
	/usr/lib/go-1.6/src/testing/testing.go:467 +0x192
panic(0x551f20, 0xc8200ae1c0)
	/usr/lib/go-1.6/src/runtime/panic.go:443 +0x4e9
reflect.Value.Elem(0x555d40, 0xc8200aa710, 0x99, 0x0, 0x0, 0x0)
	/usr/lib/go-1.6/src/reflect/value.go:735 +0x228
github.com/akutz/golf.fore(0xc8200aa760, 0x8, 0x555d40, 0xc8200aa710, 0xc8200b4390)
	/home/kontena/go/src/github.com/akutz/golf/golf.go:170 +0x1f6
github.com/akutz/golf.fore(0x58a230, 0x4, 0x5127a0, 0xc8200aa6b0, 0xc8200b4390)
	/home/kontena/go/src/github.com/akutz/golf/golf.go:215 +0x846
github.com/akutz/golf.Fore(0x58a230, 0x4, 0x5127a0, 0xc8200aa6b0, 0x8)
	/home/kontena/go/src/github.com/akutz/golf/golf.go:146 +0xad
github.com/akutz/golf.TestStructNonPointer(0xc8200ba360)
	/home/kontena/go/src/github.com/akutz/golf/golf_value_types_test.go:42 +0x72
testing.tRunner(0xc8200ba360, 0x657158)
	/usr/lib/go-1.6/src/testing/testing.go:473 +0x98
created by testing.RunTests
	/usr/lib/go-1.6/src/testing/testing.go:582 +0x892
FAIL	github.com/akutz/golf	0.005s
```